### PR TITLE
Active hashを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,4 @@ gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem "omniauth-rails_csrf_protection"
 gem 'acts-as-taggable-on', '~> 6.0'
+gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.0.3.3)
       activesupport (= 6.0.3.3)
       globalid (>= 0.3.6)
@@ -312,6 +314,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   acts-as-taggable-on (~> 6.0)
   bootsnap (>= 1.4.2)
   byebug

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -52,7 +52,7 @@ class EventsController < ApplicationController
   private
 
     def event_params
-      params.require(:event).permit(:name, :place, :content, :start_time, :end_time, :level, :tag_list)
+      params.require(:event).permit(:name, :place, :content, :start_time, :end_time, :level_id, :tag_list)
     end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,8 +15,6 @@ class Event < ApplicationRecord
   # acts_as_taggable_on :tags　と同じ意味のエイリアス
   # tags のなかにIDやら名前などが入る。イメージ的には親情報。
 
-  enum level: { "初級": 0, "初中級": 1, "中級": 2, "中上級": 3, "上級": 4 }
-
   # current_userがすでに参加しているかどうかのメソッド
   def participated_by?(user)
       participations.where(user_id: user.id).exists?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,9 @@
 class Event < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   has_many :participations
   has_many :join_users, through: :participations, source: :user
   belongs_to :owner, class_name: 'User'
+  belongs_to_active_hash :level
 
   include ActiveModel::Validations
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,0 +1,9 @@
+class Level < ActiveHash::Base
+  self.data = [
+    {id: 1, name: "初級"},
+    {id: 2, name: "初中級"},
+    {id: 3, name: "中級"},
+    {id: 4, name: "中上級"},
+    {id: 5, name: "上級"}
+  ]
+end

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -16,7 +16,7 @@
       .Event__place
         = event.place
       .Event__level
-        = event.level
+        = event.level.name
       .Event__tag
         - event.tags.each do |tag|
           = tag

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -36,9 +36,9 @@
     #levelRange
       .SettingEventForm__group.SettingEventForm__btn.displayNone
         .SettingEventForm__label
-          = f.label :level, "参加者の推奨レベル："
+          = f.label :level_id, "参加者の推奨レベル："
           %span#score 中級
         .SettingEventForm__field
-          = f.range_field :level, min: 0, max: 4, class: "form-control-range", id: "slider", style: "width: 500px;", disabled: true
+          = f.range_field :level_id, min: 0, max: 4, class: "form-control-range", id: "slider", style: "width: 500px;", disabled: true
     .SettingEventForm__group.SettingEventForm__btn
       = f.submit class: "btn btn-primary text-white"

--- a/db/migrate/20201023000436_remove_level_to_events.rb
+++ b/db/migrate/20201023000436_remove_level_to_events.rb
@@ -1,0 +1,5 @@
+class RemoveLevelToEvents < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :events, :level, :integer
+  end
+end

--- a/db/migrate/20201023001956_add_level_id_to_events.rb
+++ b/db/migrate/20201023001956_add_level_id_to_events.rb
@@ -1,0 +1,5 @@
+class AddLevelIdToEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :level_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_000436) do
+ActiveRecord::Schema.define(version: 2020_10_23_001956) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_10_23_000436) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "content", null: false
+    t.integer "level_id"
     t.index ["owner_id"], name: "index_events_on_owner_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_20_013718) do
+ActiveRecord::Schema.define(version: 2020_10_23_000436) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -21,7 +21,6 @@ ActiveRecord::Schema.define(version: 2020_09_20_013718) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "content", null: false
-    t.integer "level"
     t.index ["owner_id"], name: "index_events_on_owner_id"
   end
 


### PR DESCRIPTION
### WHAT 
・Active hashのgemを追加
・modelに記載したlevel表示のためのenumを削除
・levelを表示できるように編集

### WHY
・enumを導入すると、イベント登録ページ(form)で登録がうまくできないエラーが発生。Active hashを使用し、enumを使用せずに表示できるように変更